### PR TITLE
Correct misspelling of architectures field name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,5 +6,5 @@ sentence=Arduino library for LoRa modules based on SX1272/73 or SX1276/77/78/79 
 paragraph=Designed to be used with LoRenz Rev.B shield or module, will also work with any SX1272/73 and SX1276/77/78/79 modules.
 category=Communication
 url=https://github.com/jgromes/LoRaLib
-architecture=*
+architectures=*
 includes=LoRaLib.h


### PR DESCRIPTION
The correct spelling of the field name is architectures, not architecture.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format