### PR TITLE
Updated beginFSK to incorporate changes in initially proposed changeModulation pull request

### DIFF
--- a/src/modules/SX1272.cpp
+++ b/src/modules/SX1272.cpp
@@ -58,9 +58,9 @@ int16_t SX1272::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t sync
   return(state);
 }
 
-int16_t SX1272::beginFSK(float freq, float br, float rxBw, float freqDev, int8_t power, uint8_t currentLimit, float sh) {
+int16_t SX1272::beginFSK(float freq, float br, float rxBw, float freqDev, int8_t power, uint8_t currentLimit, float sh, bool enableOOK) {
   // execute common part
-  int16_t state = SX127x::beginFSK(SX1272_CHIP_VERSION, br, rxBw, freqDev, currentLimit);
+  int16_t state = SX127x::beginFSK(SX1272_CHIP_VERSION, br, rxBw, freqDev, currentLimit, enableOOK);
   if(state != ERR_NONE) {
     return(state);
   }

--- a/src/modules/SX1272.h
+++ b/src/modules/SX1272.h
@@ -150,9 +150,11 @@ class SX1272: public SX127x {
       
       \param sh Gaussian shaping bandwidth-time product that will be used for data shaping. Allowed values are 0.3, 0.5 or 1.0. Set to 0 to disable data shaping.
       
+      \param enableOOK Flag to specify OOK mode. This modulation is similar to FSK.
+      
       \returns \ref status_codes
     */
-    int16_t beginFSK(float freq = 915.0, float br = 48.0, float rxBw = 125.0, float freqDev = 50.0, int8_t power = 13, uint8_t currentLimit = 100, float sh = 0.3);
+    int16_t beginFSK(float freq = 915.0, float br = 48.0, float rxBw = 125.0, float freqDev = 50.0, int8_t power = 13, uint8_t currentLimit = 100, float sh = 0.3, bool enableOOK = false);
     
     // configuration methods
     

--- a/src/modules/SX1278.cpp
+++ b/src/modules/SX1278.cpp
@@ -53,7 +53,7 @@ int16_t SX1278::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t sync
 
 int16_t SX1278::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t power, uint8_t currentLimit, float sh, bool enableOOK) {
   // execute common part
-  int16_t state = SX127x::beginFSK(SX1278_CHIP_VERSION, br, freqDev, rxBw, currentLimit, enbaleOOK);
+  int16_t state = SX127x::beginFSK(SX1278_CHIP_VERSION, br, freqDev, rxBw, currentLimit, enableOOK);
   if(state != ERR_NONE) {
     return(state);
   }

--- a/src/modules/SX1278.cpp
+++ b/src/modules/SX1278.cpp
@@ -51,9 +51,9 @@ int16_t SX1278::begin(float freq, float bw, uint8_t sf, uint8_t cr, uint8_t sync
   return(state);
 }
 
-int16_t SX1278::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t power, uint8_t currentLimit, float sh) {
+int16_t SX1278::beginFSK(float freq, float br, float freqDev, float rxBw, int8_t power, uint8_t currentLimit, float sh, bool enableOOK) {
   // execute common part
-  int16_t state = SX127x::beginFSK(SX1278_CHIP_VERSION, br, freqDev, rxBw, currentLimit);
+  int16_t state = SX127x::beginFSK(SX1278_CHIP_VERSION, br, freqDev, rxBw, currentLimit, enbaleOOK);
   if(state != ERR_NONE) {
     return(state);
   }

--- a/src/modules/SX1278.h
+++ b/src/modules/SX1278.h
@@ -159,9 +159,11 @@ class SX1278: public SX127x {
       
       \param sh Gaussian shaping bandwidth-time product that will be used for data shaping. Allowed values are 0.3, 0.5 or 1.0. Set to 0 to disable data shaping.
       
+      \param enableOOK Flag to specify OOK mode. This modulation is similar to FSK.
+      
       \returns \ref status_codes
     */
-    int16_t beginFSK(float freq = 434.0, float br = 48.0, float freqDev = 50.0, float rxBw = 125.0, int8_t power = 13, uint8_t currentLimit = 100, float sh = 0.3);
+    int16_t beginFSK(float freq = 434.0, float br = 48.0, float freqDev = 50.0, float rxBw = 125.0, int8_t power = 13, uint8_t currentLimit = 100, float sh = 0.3, bool enableOOK = false);
     
     // configuration methods
     

--- a/src/modules/SX127x.cpp
+++ b/src/modules/SX127x.cpp
@@ -991,11 +991,12 @@ int16_t SX127x::config() {
 }
 
 int16_t SX127x::configFSK() {
+  int16_t state = ERR_NONE;
   //Check if we are in FSK or OOK modes
   if(_OOKEnabled)
   {
       // set OOK modulation
-      int16_t state = _mod->SPIsetRegValue(SX127X_REG_OP_MODE, SX127X_MODULATION_OOK, 6, 5, 5);
+      state = _mod->SPIsetRegValue(SX127X_REG_OP_MODE, SX127X_MODULATION_OOK, 6, 5, 5);
       if(state != ERR_NONE) {
         return(state);
       }
@@ -1003,7 +1004,7 @@ int16_t SX127x::configFSK() {
   else
   {
       // set FSK modulation
-      int16_t state = _mod->SPIsetRegValue(SX127X_REG_OP_MODE, SX127X_MODULATION_FSK, 6, 5, 5);
+      state = _mod->SPIsetRegValue(SX127X_REG_OP_MODE, SX127X_MODULATION_FSK, 6, 5, 5);
       if(state != ERR_NONE) {
         return(state);
       }

--- a/src/modules/SX127x.cpp
+++ b/src/modules/SX127x.cpp
@@ -971,6 +971,20 @@ int16_t SX127x::setFrequencyRaw(float newFreq) {
   return(state);
 }
 
+int16_t SX127x::changeModulation(uint8_t modulation)
+{
+    // check active modem
+    if(getActiveModem() != SX127X_FSK_OOK) {
+        return(ERR_WRONG_MODEM);
+    }
+    
+     // set modulation
+    int16_t state = _mod->SPIsetRegValue(SX127X_REG_OP_MODE, modulation, 6, 5, 5);
+    if(state != ERR_NONE) {
+        return(state);
+    }
+}
+
 int16_t SX127x::config() {
   // turn off frequency hopping
   int16_t state = _mod->SPIsetRegValue(SX127X_REG_HOP_PERIOD, SX127X_HOP_PERIOD_OFF);

--- a/src/modules/SX127x.h
+++ b/src/modules/SX127x.h
@@ -762,6 +762,16 @@ class SX127x: public PhysicalLayer {
     */
     int16_t setPreambleLength(uint16_t preambleLength);
     
+   /*!
+      \brief Changes the modulation from between FSK and OOK for a modem initialized with
+      beginFSK()
+      
+      \param modulation Preamble length to be set (in symbols).
+      
+      \returns \ref status_codes
+    */ 
+   int16_t changeModulation(uint8_t modulation);
+    
     /*!
       \brief Gets frequency error of the latest received packet.
       

--- a/src/modules/SX127x.h
+++ b/src/modules/SX127x.h
@@ -572,9 +572,11 @@ class SX127x: public PhysicalLayer {
       
       \param currentLimit Trim value for OCP (over current protection) in mA.
       
+      \param enableOOK Flag to specify OOK mode. This modulation is similar to FSK.
+      
       \returns \ref status_codes
     */
-    int16_t beginFSK(uint8_t chipVersion, float br, float freqDev, float rxBw, uint8_t currentLimit);
+    int16_t beginFSK(uint8_t chipVersion, float br, float freqDev, float rxBw, uint8_t currentLimit, bool enableOOK);
     
     /*!
       \brief Binary transmit method. Will transmit arbitrary binary data up to 255 bytes long using %LoRa or up to 63 bytes using FSK modem.
@@ -762,16 +764,6 @@ class SX127x: public PhysicalLayer {
     */
     int16_t setPreambleLength(uint16_t preambleLength);
     
-   /*!
-      \brief Changes the modulation from between FSK and OOK for a modem initialized with
-      beginFSK()
-      
-      \param modulation Preamble length to be set (in symbols).
-      
-      \returns \ref status_codes
-    */ 
-   int16_t changeModulation(uint8_t modulation);
-    
     /*!
       \brief Gets frequency error of the latest received packet.
       
@@ -882,6 +874,7 @@ class SX127x: public PhysicalLayer {
   
   private:
     float _dataRate;
+    bool _OOKEnabled;
   
     bool findChip(uint8_t ver);
     int16_t setMode(uint8_t mode);


### PR DESCRIPTION
Took contents of changeModulation and shifted them to configFSK. Added  enableOOK to beginFSK as a way to switch to OOK modulation. The enbleOOK flag is saved within SX127x class in _OOKEnabled. setBitRate was modify to check for allowed bit rate in OOK mode. Actual bitrate math was left untouched as both FSK and OOK follow the same math, except BitFraction has no effect and is set to 0 in OOK. I did not see where's the information on the Gaussian shaping in the datasheet.

As a side note, the datasheet does mention you can do packets larger than 64 bytes, but you have to fill the payload (tx mode) or empty it (rx mode) on the fly. I would like and will try to implement this bit later as I am not sure if my target device will be happy with fragmented payloads across packets rather than 107 byte slices (Section 4.2.13.5 of Datasheet). :)